### PR TITLE
fix: remove extra '%' in packages.md

### DIFF
--- a/src/setting_up/packages.md
+++ b/src/setting_up/packages.md
@@ -5,7 +5,7 @@ by your preferred build tool:
 
 - **With `sbt`**:
   ```scala
-  libraryDependencies += "ch.epfl.lamp" %%% "gears" % "0.2.0",
+  libraryDependencies += "ch.epfl.lamp" %% "gears" % "0.2.0",
   ```
 - **With `mill`**:
   ```scala


### PR DESCRIPTION
Fixed a small typo in `setting_up/packages.md` for adding gears dependency to `sbt`.